### PR TITLE
Cubari QoL Update

### DIFF
--- a/src/all/cubari/build.gradle
+++ b/src/all/cubari/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Cubari'
     pkgNameSuffix = "all.cubari"
     extClass = '.CubariFactory'
-    extVersionCode = 2
+    extVersionCode = 3
     libVersion = '1.2'
 }
 

--- a/src/all/cubari/src/eu/kanade/tachiyomi/extension/all/cubari/Cubari.kt
+++ b/src/all/cubari/src/eu/kanade/tachiyomi/extension/all/cubari/Cubari.kt
@@ -273,10 +273,10 @@ open class Cubari(override val lang: String) : HttpSource() {
                         chapterObj.getJSONObject("release_date").getLong(groupNum) * 1000
                 } else {
                     val currentTimeMillis = System.currentTimeMillis()
-                    if (!seriesPrefs.contains(number)) {
-                        seriesPrefsEditor.putLong(number, currentTimeMillis)
+                    if (!seriesPrefs.contains(chapterNum)) {
+                        seriesPrefsEditor.putLong(chapterNum, currentTimeMillis)
                     }
-                    chapter.date_upload = seriesPrefs.getLong(number, currentTimeMillis)
+                    chapter.date_upload = seriesPrefs.getLong(chapterNum, currentTimeMillis)
                 }
                 chapter.name = if (chapterObj.has("volume")) {
                     


### PR DESCRIPTION
### Added QoLs
1. Cases where Cubari API doesnt give the Chapter "release_date" use the Time and date when manga is updated. So it doesnt stick at the bottom for users who use "Last Updated" sorting in Tachiyomi Libary. Codes credit goes to: [ivaniskandar](https://github.com/ivaniskandar)

2. From now on Volume will be used if it is given in the Api
When Volume is given it'll show

> Vol. 1 Ch. 1 - Chapter Name 

When Volume is not given it'll show

> Ch. 1 - Chapter Name 

If both of them is given it'll still stay as in order cause how the chapter number is fetched from Cubari API

> Vol. 1 Ch. 1 - Chapter 1
> Ch. 2 - Chapter 2
> Vol. 1 Ch. 3 - Chapter 3